### PR TITLE
Fix retrieval multithreading and large integers

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest-subtests
 pytest-cov
 pytest-json-report
 ruff
+pyciff==0.1.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,3 @@ pytest-subtests
 pytest-cov
 pytest-json-report
 ruff
-pyciff==0.1.1

--- a/src/pyterrier_pisa/_pisathon.cpp
+++ b/src/pyterrier_pisa/_pisathon.cpp
@@ -439,14 +439,20 @@ static PyObject *py_retrieve(PyObject *self, PyObject *args, PyObject *kwargs) {
   auto scores = (float_t*)  result_scores.buf;
 
   auto iter = PyObject_GetIter(in_queries);
-  tbb::spin_mutex mutex;
   size_t arr_idx = 0;
 
+  PyThreadState *_save = NULL;
+  if (threads != 1) {
+    //main thread will release the GIL
+    _save = PyEval_SaveThread();
+  }
+  
   auto run = [&, threads](size_t thread_idx) {
         PyObject* res;
         int qidx;
         const char* qtext;
-        if (threads != 1) mutex.lock();
+        PyGILState_STATE gstate;
+        if (threads != 1) gstate = PyGILState_Ensure(); //acquire the GIL
         auto docnos_tmp = new std::string[k];
         std::chrono::time_point<std::chrono::high_resolution_clock> query_start;
         std::chrono::time_point<std::chrono::high_resolution_clock> query_end;
@@ -506,7 +512,7 @@ static PyObject *py_retrieve(PyObject *self, PyObject *args, PyObject *kwargs) {
           }
           Py_DECREF(res);
 
-          if (threads != 1) mutex.unlock();
+          if (threads != 1) PyGILState_Release(gstate);
 
           auto query_res = query_fun(query);
           // Stabilise the sort by sorting on score (desc), then docid (asc). See <https://github.com/pisa-engine/pisa/issues/508>
@@ -514,10 +520,10 @@ static PyObject *py_retrieve(PyObject *self, PyObject *args, PyObject *kwargs) {
             return a.first == b.first ? a.second < b.second : a.first > b.first;
           });
           auto count = query_res.size();
-          if (threads != 1) mutex.lock();
+          if (threads != 1) gstate = PyGILState_Ensure();
           size_t start = arr_idx;
           arr_idx += count;
-          if (threads != 1) mutex.unlock();
+          if (threads != 1) PyGILState_Release(gstate);
           size_t i = 0;
           for (auto r: query_res) {
             docnos_tmp[i] = docmap[r.second];
@@ -527,13 +533,13 @@ static PyObject *py_retrieve(PyObject *self, PyObject *args, PyObject *kwargs) {
           }
           std::fill(qidxs+start, qidxs+start+count, qidx);
 
-          if (threads != 1) mutex.lock();
+          if (threads != 1) gstate = PyGILState_Ensure();
           for (int i=0; i<count; ++i) {
             auto docno = PyUnicode_FromStringAndSize(docnos_tmp[i].data(), docnos_tmp[i].length());
             docnos[start+i] = docno; // takes ownership, shouldn't decref
           }
         }
-        if (threads != 1) mutex.unlock();
+        if (threads != 1) PyGILState_Release(gstate);
         delete [] docnos_tmp;
   };
 
@@ -542,6 +548,10 @@ static PyObject *py_retrieve(PyObject *self, PyObject *args, PyObject *kwargs) {
   }
   else {
     tbb::parallel_for(size_t(0), size_t(threads), run);
+  }
+
+  if (threads != 1) { //give GIL back to main thread
+    PyEval_RestoreThread(_save);
   }
 
   Py_DECREF(iter);

--- a/src/pyterrier_pisa/indexers.py
+++ b/src/pyterrier_pisa/indexers.py
@@ -128,8 +128,8 @@ class PisaToksIndexer(PisaIndexer):
       offsets_lens = []
       i = 0
       while i < in_docs.shape[0]:
-        offsets_lens.append((i, in_docs[i]+1))
-        i += in_docs[i] + 1
+        offsets_lens.append((int(i), int(in_docs[i]) + 1))
+        i += int(in_docs[i]) + 1
       for term in _logger.pbar(sorted(lexicon), desc='re-mapping term ids'):
         f_lex.write(f'{term}\n')
         i = lexicon[term]

--- a/tests/test_ciff.py
+++ b/tests/test_ciff.py
@@ -3,9 +3,18 @@ import pyterrier as pt
 import numpy as np
 import pandas as pd
 
+def pyciff_installed():
+    try:
+        import pyciff
+        return True
+    except:
+        return False
+
 class CiffTest(TempDirTestCase):
 
     def test_to_and_from_ciff(self):
+        if not pyciff_installed():
+            self.skipTest("pyciff not installed")
         from pyterrier_pisa import PisaIndex
         dataset = pt.get_dataset("vaswani")
         idx = PisaIndex(self.test_dir)


### PR DESCRIPTION
Hello,

I am a undergrad student using this package a lot for my final thesis. Thank you so much for it! I was having issues with retrieval multithreading, which was resulting in segfaults, and a small overflow error while indexing corpora with a very large amount of postings.

## Multithreading issue

I manage to hit segfaults on the latest package version and python 3.12, even with the simple setup:

```python
from pyterrier_pisa import PisaIndex

def iter_docs():
  for i in range(100000):
    yield {'docno': str(i), 'text': f'document {i}'}
index = PisaIndex('./dummy-pisa')
index.index(iter_docs())
``` 

```python
import pyterrier as pt
from pyterrier_pisa import PisaIndex
import pandas as pd

index = PisaIndex('./dummy-pisa', threads=2)
bm25 = index.bm25(k1=1.2, b=0.4)

queries_df = pd.DataFrame({
    'qid': [str(i) for i in range(10000)],
    'query': [f"search document number {i}" for i in range(10000)]
})

results = bm25.transform(queries_df)
print(results)
```

This happens because a standard mutex is not sufficient for handling with python's internal structures, since they must also acquire the GIL. I swapped the old mutex to the GIL state API, which correctly handles such concerns

## Overflow error

`in_docs` can end up overflowing on big corpora, which results in an infinite loop that loses the indexing process. Casting the number to python's integer prevents the overflow and worked for my big corpus.
